### PR TITLE
Correct train sorting

### DIFF
--- a/pi/utils.py
+++ b/pi/utils.py
@@ -34,12 +34,12 @@ class MetroApi:
 
     def _sort(data):
         if data['arrival'].isnumeric():
-            return (int(data['arrival']), data['destination'])
+            return data['arrival_timestamp']
         if data['arrival'] == 'ARR':
-            return (-1, data['destination'])
+            return datetime.now() - timedelta(seconds=60)
         if data['arrival'] == 'BRD':
-            return (-2, data['destination'])
-        return (-1000, 'Z')
+            return datetime.now() - timedelta(seconds=120)
+        return datetime.now() + timedelta(days=1)
 
     def _fetch_train_predictions(station_code: str, group: str, retry_attempt: int) -> list[dict]:
         try:
@@ -98,6 +98,8 @@ class MetroApi:
         elif line == 'BL':
             return graphics.Color(0, 0, 255)
             # return 0x0000FF
+        elif line == 'TS':
+            return graphics.Color(0, 51, 160)
         else:
             return graphics.Color(170, 170, 170)
             # return 0xAAAAAA

--- a/pi/utils.py
+++ b/pi/utils.py
@@ -34,12 +34,12 @@ class MetroApi:
 
     def _sort(data):
         if data['arrival'].isnumeric():
-            return int(data['arrival'])
+            return (int(data['arrival']), data['destination'])
         if data['arrival'] == 'ARR':
-            return -1
+            return (-1, data['destination'])
         if data['arrival'] == 'BRD':
-            return -2
-        return -1000
+            return (-2, data['destination'])
+        return (-1000, 'Z')
 
     def _fetch_train_predictions(station_code: str, group: str, retry_attempt: int) -> list[dict]:
         try:

--- a/pi/widgets/arrival.py
+++ b/pi/widgets/arrival.py
@@ -14,7 +14,7 @@ except ImportError:
 class ArrivalWidget(Widget):
 
     sleep_seconds = 1
-    update_seconds = 30
+    update_seconds = 20
     LINE_HEIGHT = 10
     LINE_HEIGHT_WITH_PADDING = 12
     WIDGET_NAME = 'DCMetroTrainArrivalWidget'
@@ -65,7 +65,7 @@ class ArrivalWidget(Widget):
                     'destination': message['message'],
                     'arrival': arrival_msg,
                     'arrival_timestamp': arrival_time,
-                    'sticky': message['sticky'] == 'true'
+                    'sticky': bool(message['sticky'])
                 })
         train_data.sort(key=MetroApi._sort)
 
@@ -78,8 +78,8 @@ class ArrivalWidget(Widget):
             # Otherwise we have real trains / non sticky messages. Remove them!
             # Find the first non-sticky at the end of the list
             for i in range(len(train_data)):
-                if not train_data[i].get('sticky', False):
-                    train_data.pop(i)
+                if not train_data[len(train_data) - i - 1].get('sticky', False):
+                    train_data.pop(len(train_data) - i - 1)
                     break
 
         self.previous_result = train_data


### PR DESCRIPTION
- Arrivals now sort by true timestamp, not arrival minute, so in general the unreliable sorting is fixed (order isn't guaranteed to be preserved between different tracks, so it's always possible for there to be some jitter, but there's no good way to solve that)
- Custom messages properly sort / overwrite based on stickiness